### PR TITLE
Add support for HX870 (issue #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # HxSync
 
-This project is an Angular web application that connects to the Standard Horizon HX890
-portable VHF radios using the WebSerial API. As of this writing, the WebSerial API is
-only available in Chrome, and this software only supports the following functions:
+This project is an Angular web application that connects to the Standard Horizon
+HX870 and HX890 portable VHF radios using the WebSerial API. As of this writing,
+the WebSerial API is only available in Chrome, and this software only supports
+the following functions:
 
 - Reading and editing waypoints
 - Downloading the GPS log as a GPX file
@@ -11,7 +12,8 @@ It is very incomplete, and could break your device. **Use at your own risk!**
 
 This software builds on the work published at
 [Robert Elsinga's page on the HX890](https://pc5e.nl/info/standard-horizon-hx890e-marine-handheld)
-as well as the [`hxtool` Python utility](https://github.com/cr/hx870) by Christiane Ruetten.
+as well as the [`hxtool` Python utility](https://github.com/cr/hx870) by
+Christiane Ruetten.
 
 ## Demo
 
@@ -22,16 +24,21 @@ https://github.com/mbof/hxsync/assets/1308709/8ee0a733-05c3-474d-b0bf-59fce52ff4
 
 ## Development server
 
-Run `ng serve --serve-path hx` for a dev server. Navigate to `http://localhost:4200/hx`. The application will automatically reload if you change any of the source files.
+Run `ng serve --serve-path hx` for a dev server. Navigate to
+`http://localhost:4200/hx`. The application will automatically reload if you
+change any of the source files.
 
 ## Code scaffolding
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+Run `ng generate component component-name` to generate a new component. You can
+also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
 
 ## Build
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
+Run `ng build` to build the project. The build artifacts will be stored in the
+`dist/` directory.
 
 ## Running unit tests
 
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
+Run `ng test` to execute the unit tests via
+[Karma](https://karma-runner.github.io).

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,8 +2,8 @@
   <div class="content">
     <h1>HxSync</h1>
     <div class="desc">
-      With this utility, you'll be able to edit waypoints on your HX890, and
-      download its GPS log in GPX format.
+      With this utility, you'll be able to edit waypoints on your HX870 or
+      HX890, and download its GPS log in GPX format.
     </div>
     <div class="desc">
       This experimental utility is not provided by Standard Horizon. Use at your

--- a/src/app/device/device.component.html
+++ b/src/app/device/device.component.html
@@ -3,8 +3,8 @@
   <div class="controls">
     @if (connectionState != 'connected') {
       <div class="desc">
-        Connect your HX890 radio to this computer with a USB cable, and place it
-        in "CP Mode":
+        Connect your HX870 or HX890 radio to this computer with a USB cable, and
+        place it in "CP Mode":
         <ol>
           <li>Power the device off</li>
           <li>Press and hold the Menu key</li>


### PR DESCRIPTION
This is intended to add support for HX870 (issue #4)

I have not tested this.

The device IDs are sourced from https://github.com/cr/hx870/blob/master/hxtool/device.py

The waypoint memory locations are sourced from https://pc5e.nl/info/standard-horizon-hx890e-marine-handheld

> The waypoints in the 890E DAT file are [identically formatted as in the 870](https://johannessen.github.io/hx870/#wpt-def), but there are now 250 of them and they are listed from 0xD700 to 0xF63F instead of 0x4300 to 0x5BFF in the DAT file.
