### PR TITLE
Fix off-by-one error for "noise cancel Rx level" setting

### DIFF
--- a/src/app/config-modules/preferences-knobs.ts
+++ b/src/app/config-modules/preferences-knobs.ts
@@ -175,9 +175,8 @@ export const controlKnobsData = [
     id: 'noise_cancel_rx_level',
     address: 0x0044,
     params: {
-      type: 'number',
-      min: 0,
-      max: 3
+      type: 'enum',
+      values: ['1', '2', '3', '4']
     }
   },
   {


### PR DESCRIPTION
I’m *fairly* certain this particular setting is off by one on the HX870: The radio UI offers levels 1–4, but the stored values are 0–3.

Can you confirm that with your HX890?