### PR TITLE
Add Norwegian nautical charts to waypoint map

### DIFF
--- a/src/app/waypoint-sheet/waypoint-sheet.component.ts
+++ b/src/app/waypoint-sheet/waypoint-sheet.component.ts
@@ -95,8 +95,8 @@ export class WaypointSheetComponent {
     };
 
     const overlayMaps = {
-      OpenSeaMap: openSeaMap,
-      'NOAA Charts': noaaLayer
+      '🌐 OpenSeaMap': openSeaMap,
+      '🇺🇸 NOAA Charts': noaaLayer
     };
 
     L.control.layers(baseMaps, overlayMaps).addTo(this.map);

--- a/src/app/waypoint-sheet/waypoint-sheet.component.ts
+++ b/src/app/waypoint-sheet/waypoint-sheet.component.ts
@@ -79,6 +79,7 @@ export class WaypointSheetComponent {
     const noaaLayer = L.tileLayer.wms(
       'https://gis.charttools.noaa.gov/arcgis/rest/services/MCS/NOAAChartDisplay/MapServer/exts/MaritimeChartService/WMSServer',
       {
+        bounds: [ [-20, -230], [80, -60] ],
         format: 'image/png',
         transparent: true,
         attribution: 'NOAA Office of Coast Survey'

--- a/src/app/waypoint-sheet/waypoint-sheet.component.ts
+++ b/src/app/waypoint-sheet/waypoint-sheet.component.ts
@@ -75,6 +75,16 @@ export class WaypointSheetComponent {
       }
     );
 
+    // Norwegian Hydrographic Service (tiles licensed CC-BY 4.0)
+    const kartverketLayer = L.tileLayer(
+      'https://cache.kartverket.no/v1/wmts/1.0.0/sjokartraster/default/webmercator/{z}/{y}/{x}.png',
+      {
+        bounds: [ [56, -14], [82, 38] ],
+        maxNativeZoom: 16,
+        attribution: '© <a href="https://www.kartverket.no/en">Kartverket</a>'
+      }
+    );
+
     // NOAA WMS Layer
     const noaaLayer = L.tileLayer.wms(
       'https://gis.charttools.noaa.gov/arcgis/rest/services/MCS/NOAAChartDisplay/MapServer/exts/MaritimeChartService/WMSServer',
@@ -88,6 +98,7 @@ export class WaypointSheetComponent {
 
     osmBase.addTo(this.map);
     openSeaMap.addTo(this.map);
+    kartverketLayer.addTo(this.map);
     noaaLayer.addTo(this.map);
 
     const baseMaps = {
@@ -96,6 +107,7 @@ export class WaypointSheetComponent {
 
     const overlayMaps = {
       '🌐 OpenSeaMap': openSeaMap,
+      '🇳🇴 Kartverket': kartverketLayer,
       '🇺🇸 NOAA Charts': noaaLayer
     };
 


### PR DESCRIPTION
(as we discussed by email)

It's less than ideal that the community-run servers for OSM and OSeaM are always polled, even when those tiles aren't even visible because they're covered by Norwegian or American charts. Unfortunately, I don't see a simple fix for that.

I think you'd have to get a detailed coverage polygon. Then you'd need to check if the viewed map extent is wholly within the polygon of an enabled overlay. The latter part is probably easy, but the first part may prove challenging especially for the NOAA overlay.